### PR TITLE
Fix SharePoint file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# PrintPlus Service
+
+PrintPlus is a background service for processing work orders and printing documentation.
+It downloads attachments from external sources (such as SharePoint) and prepares
+files for printing with SAP and local printers.
+
+The solution targets **.NET 8** (see `global.json`).
+
+## Building
+
+Use the .NET SDK 8.0 to build and run tests:
+
+```bash
+dotnet test --no-build
+```
+
+SAP native libraries are required at runtime and are included in the repository.
+
+## Recent Changes
+
+### SharePoint file download improvements
+
+- `SharePointService` now assigns unique filenames when downloading files
+  from SharePoint. Files with identical names no longer overwrite each other.
+- A numeric counter is appended before the file extension to keep each
+  downloaded path distinct.
+- Repeated requests for the same SharePoint link now return the already
+  downloaded file instead of creating duplicate copies.
+- Additional inline comments explain this behaviour in `SharePointService.cs`.


### PR DESCRIPTION
## Summary
- prevent SharePoint downloads from overwriting files with same name
- generate unique filenames when downloading attachments
- add README file documenting recent changes
- avoid duplicate downloads by caching share links

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68639abfbc98832eaeea6eb11fa875b0